### PR TITLE
Fix claimant link to use owner address

### DIFF
--- a/src/poap2rss_lambda.py
+++ b/src/poap2rss_lambda.py
@@ -371,7 +371,7 @@ class RSSFeedGenerator:
         SubElement(item, 'author').text = f"{display_name} ({owner_address})"
         
         description = f"""
-        <p><strong><a href="https://collectors.poap.xyz/scan/{display_name}">{display_name}</a></strong> 
+        <p><strong><a href="https://collectors.poap.xyz/scan/{owner_address}">{display_name}</a></strong>
         claimed POAP <a href="https://collectors.poap.xyz/token/{token_id}">{token_id}</a> for 
         <strong>{event_details.get('name', 'Unknown Event')}</strong></p>
         """


### PR DESCRIPTION
## Summary
- fix owner link generation to use wallet address

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686738c824a483219dd5d4ddb414032c