### PR TITLE
Fix description typo

### DIFF
--- a/src/poap2rss_lambda.py
+++ b/src/poap2rss_lambda.py
@@ -271,7 +271,7 @@ class RSSFeedGenerator:
         event_id = event_details.get('id', 'unknown')
         
         SubElement(channel, 'title').text = f"POAP: {event_name}"
-        SubElement(channel, 'description').text = f"Acvitity for {event_name} POAP drop."
+        SubElement(channel, 'description').text = f"Activity for {event_name} POAP drop."
         SubElement(channel, 'link').text = f"https://poap.gallery/drops/{event_id}"
         SubElement(channel, 'language').text = 'en-us'
         SubElement(channel, 'lastBuildDate').text = formatdate(timeval=time.time(), localtime=False, usegmt=True)


### PR DESCRIPTION
## Summary
- fix a typo in `_add_channel_metadata` description text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673be5b0d48321b37cf029d3be2462