### PR TITLE
Rename dormant page to inactive

### DIFF
--- a/src/poap2rss_lambda.py
+++ b/src/poap2rss_lambda.py
@@ -493,8 +493,8 @@ class RSSFeedGenerator:
             """
             
             # Use unique GUID for each week to ensure new notifications
-            SubElement(item, 'guid').text = f"https://www.poap2rss.com/dormant.html?event={event_details.get('id', 'unknown')}&week={weeks_since_last_claim}"
-            SubElement(item, 'link').text = f"https://www.poap2rss.com/dormant.html?event={event_details.get('id', 'unknown')}&week={weeks_since_last_claim}"
+            SubElement(item, 'guid').text = f"https://www.poap2rss.com/inactive.html?event={event_details.get('id', 'unknown')}&week={weeks_since_last_claim}"
+            SubElement(item, 'link').text = f"https://www.poap2rss.com/inactive.html?event={event_details.get('id', 'unknown')}&week={weeks_since_last_claim}"
             SubElement(item, 'pubDate').text = formatdate(timeval=time.time(), localtime=False, usegmt=True)
         else:
             logger.info(f"No inactivity alert needed (only {weeks_since_last_claim} weeks since last claim)")

--- a/www/inactive.html
+++ b/www/inactive.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Dormant Feed - POAP2RSS</title>
+  <title>Inactive Feed - POAP2RSS</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <style>
     :root { --pico-primary: #5c4df3; }
@@ -24,7 +24,7 @@
   </header>
 
   <main class="container">
-    <h2>This POAP feed is dormant</h2>
+    <h2>This POAP feed is inactive</h2>
     <p>No POAP claims have been recorded for this event in several weeks. If you're subscribed to this feed you may want to remove it from your reader.</p>
     <p>You can always resubscribe later if activity picks up again.</p>
   </main>


### PR DESCRIPTION
## Summary
- rename `dormant.html` to `inactive.html`
- update references in `poap2rss_lambda.py`
- update heading and title in the inactive page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68690ee3b8b88321b6e2f4527af61a37